### PR TITLE
Improved README Instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+poetry.lock
+.envrc
+.direnv
 MANIFEST
 
 # PyInstaller

--- a/README.md
+++ b/README.md
@@ -6,13 +6,34 @@ There are two examples here:
 1. A demo project
 2. A demo plugin
 
+## Setup python env
+
+Install poetry
+```bash
+pip3 install poetry
+```
+
+Install project
+```bash
+poetry install
+```
+
+Activate venv shell
+```bash
+poetry shell
+```
+
+Install eth-ape (poetry add failes for some dependency conflict)
+```bash
+pip install eth-ape
+```
 ## Demo Project
 
 The demo project is found in the `project/` directory.
 Install the plugins by doing:
 
 ```bash
-ape plugins install
+ape plugins install .
 ```
 
 List your existing plugins by doing:
@@ -28,6 +49,24 @@ ape compile
 ```
 
 Try running the tests:
+
+## Deploy Contract
+
+Setup environment variable `WEB3_ALCHEMY_API_KEY`
+```bash
+export WEB3_ALCHEMY_API_KEY=<someKey>
+```
+
+generate test account
+```bash
+ape accounts test
+```
+
+Install token list
+```bash
+ape tokens install tokens.1inch.eth
+```
+
 
 ## Demo Plugin
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[tool.poetry]
+name = "ape-ethdenver"
+version = "0.1.0"
+description = "ETH Denver ape test project"
+authors = [""]
+
+
 [build-system]
 requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 


### PR DESCRIPTION
Update gitignore for additional env settings
Added more specific instructions for the example code
- add accounts creation
- add token list fetching command
Fixed poetry config to be able to use manage venv

Note: poetry doesn't allow eth-ape to be installed due to some dependency conflict.